### PR TITLE
SB/28-Prevent-All-Admin-Loss

### DIFF
--- a/TabloidMVC/Controllers/UserProfileController.cs
+++ b/TabloidMVC/Controllers/UserProfileController.cs
@@ -103,15 +103,32 @@ namespace TabloidMVC.Controllers
         [ValidateAntiForgeryToken]
         public ActionResult EditType(UserProfileViewModel vm)
         {
-            try
+            // Check if user type has been toggled to Author (implying that it was Admin) and if it's the final admin
+            if (vm.UserProfile.UserTypeId == 2 && _userProfileRepository.IsLastAdmin(vm.UserProfile.UserTypeId))
             {
-                _userProfileRepository.ChangeType(vm.UserProfile);
+                // Get the data to recreate the view model
+                List<UserType> userTypes = _userTypeRepository.GetUserTypes();
+                UserProfile user = _userProfileRepository.GetById(vm.UserProfile.Id);
+                vm.UserTypes = userTypes;
+                vm.UserProfile = user;
 
-                return RedirectToAction(nameof(Index));
-            }
-            catch
-            {
+                // Add a message to be displayed in the view
+                vm.Message = $"Sorry! This user is the final admin and cannot be changed!";
+
                 return View(vm);
+            }
+            else
+            {
+                try
+                {
+                    _userProfileRepository.ChangeType(vm.UserProfile);
+
+                    return RedirectToAction(nameof(Index));
+                }
+                catch
+                {
+                    return View(vm);
+                }
             }
         }
 

--- a/TabloidMVC/Models/ViewModels/UserProfileViewModel.cs
+++ b/TabloidMVC/Models/ViewModels/UserProfileViewModel.cs
@@ -7,5 +7,6 @@ namespace TabloidMVC.Models.ViewModels
         public UserProfile UserProfile { get; set; }
         public List<UserProfile> UserProfiles { get; set; } 
         public List<UserType> UserTypes { get; set; }
+        public string Message { get; set; }
     }
 }

--- a/TabloidMVC/Repositories/IUserProfileRepository.cs
+++ b/TabloidMVC/Repositories/IUserProfileRepository.cs
@@ -10,5 +10,11 @@ namespace TabloidMVC.Repositories
         UserProfile GetByEmail(string email);
         void AddUser(UserProfile user);
         void ChangeType(UserProfile user);
+
+        /// <summary>
+        /// Queries UserProfile table for admin count
+        /// </summary>
+        /// <returns>True if admin count = 1, else false</returns>
+        bool IsLastAdmin(int id);
     }
 }

--- a/TabloidMVC/Repositories/UserProfileRepository.cs
+++ b/TabloidMVC/Repositories/UserProfileRepository.cs
@@ -199,5 +199,43 @@ namespace TabloidMVC.Repositories
                 }
             }
         }
+
+        public bool IsLastAdmin(int typeId)
+        {
+            using (var conn = Connection)
+            {
+                conn.Open();
+                using (var cmd = conn.CreateCommand())
+                {
+                    cmd.CommandText = @"
+                            SELECT COUNT(*) AS 'AdminCount'
+                            FROM UserProfile
+                            GROUP BY UserTypeId
+                            HAVING UserTypeId = 1";
+
+                    var reader = cmd.ExecuteReader();
+
+                    int adminCount = 0;
+
+                    if (reader.Read())
+                    {
+
+                        adminCount = reader.GetInt32(reader.GetOrdinal("AdminCount"));
+
+                        reader.Close();
+
+                    }
+                    if (adminCount == 1)
+                    {
+                            return true;
+                    }
+                    else
+                    {
+                        return false;
+                    }
+                }
+            }
+        }
+
     }
 }

--- a/TabloidMVC/Views/UserProfile/EditType.cshtml
+++ b/TabloidMVC/Views/UserProfile/EditType.cshtml
@@ -14,28 +14,33 @@
             <hr />
             <form asp-action="EditType">
                 <dl class="row">
-                <dt class="col-sm-2">
-                    @Html.DisplayNameFor(model => model.UserProfile.UserType)
-                </dt>
-                    <div asp-validation-summary="ModelOnly" class="text-danger"></div>
-                    <div class="form-group">
-                        <input asp-for="UserProfile.Id" type="hidden" class="form-control" />
-                    </div>
-                    <div class="form-group">
-                        <select placeholder="UserTypeId" asp-for="UserProfile.UserTypeId" class="form-control">
-                            <option value="">Select User Type</option>
-                            @foreach (UserType type in Model.UserTypes)
-                            {
-                                <option value="@type.Id">@type.Name</option>
-                            }
-                        </select>
-                        <span asp-validation-for="UserProfile.UserTypeId" class="text-danger"></span>
-                    </div>
-                    <div class="form-group ml-4">
-                        <input type="submit" value="Change" class="btn btn-primary btn-block">
-                        <input type="button" value="Cancel" class="btn btn-primary btn-block" onclick="location.href='@Url.Action("Index","UserProfile")';" />
-                    </div>
+                    <dt class="col-sm-2">
+                        @Html.DisplayNameFor(model => model.UserProfile.UserType)
+                    </dt>
+                        <div asp-validation-summary="ModelOnly" class="text-danger"></div>
+                        <div class="form-group">
+                            <input asp-for="UserProfile.Id" type="hidden" class="form-control" />
+                        </div>
+                        <div class="form-group">
+                            <select placeholder="UserTypeId" asp-for="UserProfile.UserTypeId" class="form-control">
+                                <option value="">Select User Type</option>
+                                @foreach (UserType type in Model.UserTypes)
+                                {
+                                    <option value="@type.Id">@type.Name</option>
+                                }
+                            </select>
+                            <span asp-validation-for="UserProfile.UserTypeId" class="text-danger"></span>
+                        </div>
+                        <div class="form-group ml-4">
+                            <input type="submit" value="Change" class="btn btn-primary btn-block">
+                            <input type="button" value="Cancel" class="btn btn-primary btn-block" onclick="location.href='@Url.Action("Index","UserProfile")';" />
+                        </div>
+                    </dl>
                 </form>
+            @if (!string.IsNullOrEmpty(Model.Message))
+            {
+                <h4 class="text-danger">@Model.Message</h4>
+            }
         </section>
     </div>
 </div>


### PR DESCRIPTION
# Description

This PR protects loss of the final admin that could previously happen if a user changed the final admin to author.

# Testing Instructions

1. Launch application from SB/28-Prevent-All-Admin-Loss branch
2. In the app, Login as admin@example.com
3. Go to "Users" on the nav bar
5. You should be greeted with a list of users from the database's UserProfile table
6. Follow a user's pencil icon button to navigate to a change type page
7. On this page you should be able to change user type to and from admin or author
8. Change users to authors until there is only one admin remaining
9. When attempting to change the final admin to author, you should be greeted with a message saying that it cannot be changed
10. Click cancel and go back to user list and ensure that there is still one admin remaining

If you don't have data for the UserProfile table, you may utilize this SQL query to seed 3 new users to table.
```SQL
INSERT INTO [UserProfile] 
([FirstName], [LastName], [DisplayName], [Email], [CreateDateTime], [ImageLocation], [UserTypeId])
VALUES 
('Jess', 'Ximenez', 'ximjess', 'jess8000@yahoo.com', SYSDATETIME(), 'https://cdn.pixabay.com/photo/2016/08/08/09/17/avatar-1577909_960_720.png', 2),
('Rick', 'Rust', 'rustyrick', 'rstnvrslps@hotmail.com', SYSDATETIME(), 'https://cdn.pixabay.com/photo/2016/08/08/09/17/avatar-1577909_960_720.png', 2),
('Bianca', 'Bolander', 'bboland', 'berezepz@gmail.com', SYSDATETIME(), 'https://cdn.pixabay.com/photo/2016/08/08/09/17/avatar-1577909_960_720.png', 2);
```

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings or errors
- [x] I have added test instructions that prove my fix is effective or that my feature works
